### PR TITLE
Fix Step in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ od2samba4 will *only* migrate groups listed in `groups.json`, so make sure to mi
 
 Groups can then be imported using
 ```bash
-ldbadd -H /var/lib/samba/private/sam.ldb <group ldif file> --relax
+ldbmodify -H /var/lib/samba/private/sam.ldb <group ldif file> --relax
 ```
 
 Additionally, a script that establishes **secondary** group membership and parent-children relationships between groups (nested groups) is created. This script has to be executed *after* users have been imported!


### PR DESCRIPTION
Some minor changes to the README.md as I go along:

### Use ldbmodify instead of ldbadd 
because the addgroups.ldif uses "changetype: add" and "changetype: modify"
```
# ldbadd -H /var/lib/samba/private/sam.ldb addgroups.ldif --relax
Only CHANGETYPE_ADD records allowed
Failed to parse ldif
Added 79 records successfully
```
Changed to
```
# ldbmodify -H /var/lib/samba/private/sam.ldb addgroups.ldif --relax
Modified 95 records successfully
```